### PR TITLE
Removes /elendev-roxyfileman prefix and updates installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,16 @@ Update composer :
     $ composer update
 ```
 
+Import the bundle's routes to your routing configuration file, e.g. `routing.yml`:
+
+```
+ElendevRoxyFilemanBundle:
+    resource: "@ElendevRoxyFilemanBundle/Resources/config/routing.yml"
+    prefix:   /elendev-roxyfileman
+```
+
+The prefix can be changed. You can also add the path to the firewall to have the file manager service protected.  
+ 
 ## Configuration
 RoxyFilemanBundle provide a simple configuration.
 
@@ -73,6 +83,22 @@ Every configuration options are available on the [Roxyfileman configuration page
 
 The parameters have to be in lowercase.
 **Be careful** : every url parameter available on the [Roxyfileman configuration page](http://www.roxyfileman.com/install) should be used as a route here and the parameter have to be postfixed by `_route`. For example : the parameter `DIRLIST` becomes `dirlist_route`.
+
+### Integration with rich text editor
+
+The original index path `/fileman/index.html` is served by the route `elendev_roxyfileman_index` in this bundle, and is what you need to integrate with rich text editors like CKEditor. For example:
+
+```
+<script> 
+$(function(){
+   CKEDITOR.replace( 'editor1', {
+        filebrowserBrowseUrl: '{{ path('elendev_roxyfileman_index') }}',
+        filebrowserImageBrowseUrl: '{{ path('elendev_roxyfileman_index') }}?type=image',
+        removeDialogTabs: 'link:upload;image:upload'
+   }); 
+});
+ </script>
+```
 
 ## Advanced customization
 

--- a/Resources/config/routing.yml
+++ b/Resources/config/routing.yml
@@ -1,75 +1,75 @@
 
 elendev_roxyfileman_conf:
-    path:     /elendev-roxyfileman/resources/conf.json
+    path:     /resources/conf.json
     defaults: { _controller: ElendevRoxyFilemanBundle:Conf:conf }
 
 elendev_roxyfileman_index:
-    path:     /elendev-roxyfileman/resources/index.html
+    path:     /resources/index.html
     defaults: { _controller: ElendevRoxyFilemanBundle:Resources:resource, file: 'index.html' }
 
 elendev_roxyfileman_resource:
-    path:     /elendev-roxyfileman/resources/{file}
+    path:     /resources/{file}
     defaults: { _controller: ElendevRoxyFilemanBundle:Resources:resource }
     requirements:
         file: '[a-zA-Z0-9\-\/\._]+\.(?:css|html|js|json|gif|png)'
 
 elendev_roxyfileman_dir_list:
-    path:     /elendev-roxyfileman/api/dirList
+    path:     /api/dirList
     defaults: { _controller: ElendevRoxyFilemanBundle:Directory:dirList }
 
 elendev_roxyfileman_create_dir:
-    path:     /elendev-roxyfileman/api/createDir
+    path:     /api/createDir
     defaults: { _controller: ElendevRoxyFilemanBundle:Directory:createDir }
 
 elendev_roxyfileman_delete_dir:
-    path:     /elendev-roxyfileman/api/deleteDir
+    path:     /api/deleteDir
     defaults: { _controller: ElendevRoxyFilemanBundle:Directory:deleteDir }
 
 elendev_roxyfileman_move_dir:
-    path:     /elendev-roxyfileman/api/moveDir
+    path:     /api/moveDir
     defaults: { _controller: ElendevRoxyFilemanBundle:Directory:moveDir }
 
 elendev_roxyfileman_copy_dir:
-    path:     /elendev-roxyfileman/api/copyDir
+    path:     /api/copyDir
     defaults: { _controller: ElendevRoxyFilemanBundle:Directory:copyDir }
 
 elendev_roxyfileman_rename_dir:
-    path:     /elendev-roxyfileman/api/renameDir
+    path:     /api/renameDir
     defaults: { _controller: ElendevRoxyFilemanBundle:Directory:renameDir }
 
 elendev_roxyfileman_file_list:
-    path:     /elendev-roxyfileman/api/fileList
+    path:     /api/fileList
     defaults: { _controller: ElendevRoxyFilemanBundle:Directory:fileList }
 
 elendev_roxyfileman_upload:
-    path:     /elendev-roxyfileman/api/upload
+    path:     /api/upload
     defaults: { _controller: ElendevRoxyFilemanBundle:Directory:upload }
 
 elendev_roxyfileman_download:
-    path:     /elendev-roxyfileman/api/download
+    path:     /api/download
     defaults: { _controller: ElendevRoxyFilemanBundle:Directory:download }
 
 elendev_roxyfileman_download_dir:
-    path:     /elendev-roxyfileman/api/downloadDir
+    path:     /api/downloadDir
     defaults: { _controller: ElendevRoxyFilemanBundle:Directory:downloadDir }
 
 elendev_roxyfileman_delete_file:
-    path:     /elendev-roxyfileman/api/deleteFile
+    path:     /api/deleteFile
     defaults: { _controller: ElendevRoxyFilemanBundle:Directory:deleteFile }
 
 elendev_roxyfileman_move_file:
-    path:     /elendev-roxyfileman/api/moveFile
+    path:     /api/moveFile
     defaults: { _controller: ElendevRoxyFilemanBundle:Directory:moveFile }
 
 elendev_roxyfileman_copy_file:
-    path:     /elendev-roxyfileman/api/copyFile
+    path:     /api/copyFile
     defaults: { _controller: ElendevRoxyFilemanBundle:Directory:copyFile }
 
 elendev_roxyfileman_rename_file:
-    path:     /elendev-roxyfileman/api/renameFile
+    path:     /api/renameFile
     defaults: { _controller: ElendevRoxyFilemanBundle:Directory:renameFile }
 
 elendev_roxyfileman_generate_thumb:
-    path:     /elendev-roxyfileman/api/generateThumb
+    path:     /api/generateThumb
     defaults: { _controller: ElendevRoxyFilemanBundle:Directory:generateThumb }
 


### PR DESCRIPTION
Hi,

First of all, thank you for your bundle. I spent couple of hours finding a file manager that can integrate with CKEditor and reside in my Symfony2 app so that its access can be protected by the framework's security system. Your bundle fits my requirement exactly.

In this pull request I made the following changes:

  * added instructions in README about importing bundle's routeing configuration in app's `routing.yml`.
  * added example on rich text editor integration, mainly to highlight the `elendev_roxyfileman_index` route.
  * removed "/elendev-roxyfileman" from the bundle's routing.yml, as the prefix path should be configurable by the app's `routing.yml` file via the `prefix` key (this is shown in the modified README).

I hope this can make installation easier. Removing the `/elendev-roxyfileman` in the bundle may cause  backward compatibility issue, but I believe this is a welcome change, as it enables more flexible routing.

Being completely new to your bundle and Roxy file manager I am not sure if I understand the bundle correctly, so feel free to correct me. Thanks!